### PR TITLE
fixed a bug inside Clusterizer.deleteCluster function

### DIFF
--- a/include/cluster.hpp
+++ b/include/cluster.hpp
@@ -195,10 +195,12 @@ public:
 		clusterIDtoLoopsMap.erase(clusterID);
 
 		for(IntPairIDMap::iterator it= loopToClusterIDMap.begin();
-				it!=loopToClusterIDMap.end(); it++)
+				it!=loopToClusterIDMap.end(); /*no increment*/)
 		{
 			if(it->second == clusterID)
-				loopToClusterIDMap.erase(it->first);
+				it = loopToClusterIDMap.erase(it);
+			else
+				++it;
 		}
 
 		return true;


### PR DESCRIPTION
Changes made:
Updated Clusterizer.deleteCluster function to correctly delete items while iterating through IntPairIDMap.

Problem:
Previous code would sometimes cause a segfault as the iterator became invalidated from the delete.

Problem replication:
I don't know if the segfault is replicable on a different machine, but below are the steps.
On the city10000.g2o dataset from [https://github.com/OpenSLAM-org/openslam_vertigo/blob/master/datasets/city10000/originalDataset/city10000.g2o](url),
add 500 random faulty loop closures using generateDataset.py from [https://github.com/OpenSLAM-org/openslam_vertigo/blob/master/datasets/generateDataset.py](url)
`python2 generateDataset.py -i city10000.g2o --seed 7 -n 500 -g 1 -o city10000_seed7_N500G1.g2o`
then run `RRR_2D_optimizer_g2o  city10000_seed7_N500G1.g2o 10`
where RRR_2D_optimizer_g2o is the executable from compiling examples/2D_optimizer_g2o.cpp
The program runs about 12 minutes before it segfaults.

You also need to add a trailing newline to city10000.g2o before running generateDataset.py on it.